### PR TITLE
Handle insecure connections, multiple updates in one notification response, and save channel for disconnect.

### DIFF
--- a/connector/setup.py
+++ b/connector/setup.py
@@ -182,7 +182,7 @@ setup(
         'paramiko >= 1.15.1',
         'lxml >= 3.3.0',
         'ncclient >= 0.6.6',
-        'cisco-gnmi',
+        'cisco-gnmi >= 1.0.13, < 2.0.0',
     ],
 
     # any additional groups of dependencies.

--- a/connector/src/yang/connector/gnmi.py
+++ b/connector/src/yang/connector/gnmi.py
@@ -444,6 +444,10 @@ class Gnmi(BaseConnection):
             return []
         json_val = base64.b64decode(val).decode('utf-8')
         update_val = json.loads(json_val)
+        if not isinstance(update_val, (dict, list)):
+            # Just one value returned
+            opfields.append((update_val, xpath_str))
+            return opfields
         if isinstance(update_val, dict):
             opfields = self.get_opfields(
                 update_val,
@@ -459,9 +463,6 @@ class Gnmi(BaseConnection):
                     opfields,
                     namespace
                 )
-        else:
-            # Just one value returned
-            opfields.append((update_val, xpath_str))
         return opfields
 
     def decode_update(self, update={}, namespace={}):

--- a/connector/src/yang/connector/gnmi.py
+++ b/connector/src/yang/connector/gnmi.py
@@ -465,7 +465,7 @@ class Gnmi(BaseConnection):
         return opfields
 
     def decode_update(self, update={}, namespace={}):
-        # TODO: the val depends on the encoding type
+        """Convert JSON return to python dict for display or processing."""
         val = update.get('val', {}).get('jsonIetfVal', '')
         if not val:
             val = update.get('val', {}).get('jsonVal', '')
@@ -492,14 +492,14 @@ class Gnmi(BaseConnection):
             for update in notify['update']:
                 val_dict = self.decode_update(update, namespace=namespace)
                 opfields = self.decode_opfields(update, namespace=namespace)
+                if 'decode' not in ret_val:
+                    ret_val['decode'] = [val_dict]
+                else:
+                    ret_val['decode'].append(val_dict)
                 if 'update' not in ret_val:
-                    ret_val['update'] = [val_dict]
+                    ret_val['update'] = [opfields]
                 else:
-                    ret_val['update'].append(val_dict)
-                if 'opfields' not in ret_val:
-                    ret_val['opfields'] = [opfields]
-                else:
-                    ret_val['opfields'].append(opfields)
+                    ret_val['update'].append(opfields)
             deletes = notify.get('delete', [])
             deleted = []
             for delete in deletes:

--- a/connector/src/yang/connector/gnmi.py
+++ b/connector/src/yang/connector/gnmi.py
@@ -448,6 +448,9 @@ class Gnmi(BaseConnection):
             # Just one value returned
             opfields.append((update_val, xpath_str))
             return opfields
+        else:
+            # Reset opfields to avoid duplicates
+            opfields = []
         if isinstance(update_val, dict):
             opfields = self.get_opfields(
                 update_val,


### PR DESCRIPTION
- Must set insecure mode for cisco-gnmi insecure connections with new version of cisco-gnmi.
- User needs the gRPC channel in order to "close" it and new version of cisco-gnmi returns channel
- If a user retrieves nested lists with different formats the list is returned with multiple updates in one notification response.  For example, GET openconfig-network-instance returns 4 updates in a single notification:
```
path {
  origin: "openconfig"
  elem {
    name: "network-instances"
  }
  elem {
    name: "network-instance"
  }
}
```
