### PR TITLE
Notification testing not working for gnmi

### DIFF
--- a/connector/src/yang/connector/gnmi.py
+++ b/connector/src/yang/connector/gnmi.py
@@ -113,6 +113,7 @@ class GnmiNotification(Thread):
         try:
             for response in self.responses:
                 if self.stopped():
+                    self.time_delta = self.stream_max
                     self.log.info("Terminating notification thread")
                     break
                 if response.HasField('sync_response'):

--- a/connector/src/yang/connector/gnmi.py
+++ b/connector/src/yang/connector/gnmi.py
@@ -464,7 +464,7 @@ class Gnmi(BaseConnection):
         json_val = base64.b64decode(val).decode('utf-8')
         return json.loads(json_val)
 
-    def decode_notification(self, response, namespace):
+    def decode_notification(self, response, namespace={}):
         """Decode a response from the google.protobuf into a dict."""
         if isinstance(response, dict):
             resp_dict = response

--- a/connector/src/yang/connector/gnmi.py
+++ b/connector/src/yang/connector/gnmi.py
@@ -737,7 +737,7 @@ class Gnmi(BaseConnection):
                     return False
             else:
                 cmd['namespace'] = ns
-                cmd['decode'] = self.decode_notification
+                cmd['decode'] = self.decode_update
                 subscribe_thread = GnmiNotification(
                     self,
                     subscribe_response,

--- a/connector/src/yang/connector/netconf.py
+++ b/connector/src/yang/connector/netconf.py
@@ -418,20 +418,24 @@ class Netconf(manager.Manager, BaseConnection):
                 del self.active_notifications[self]
                 return
             notification.event_triggered = True
-            log.info('NOTIFICATION EVENT TRIGGERED')
+            logger.info('NOTIFICATION EVENT TRIGGERED')
             # Activate notification listener and process the notifications if any exists
             notification.start()
             while notification.time_delta < notification.stream_max:
-                log.info('WAITING FOR NOTIFICATION RESPONSE')
+                logger.info('WAITING FOR NOTIFICATION RESPONSE')
                 if notification.result is not None:
                     if notification.result is True:
                         steps.passed(
-                            'NOTIFICATION RESPONSE PASSED'
+                            '\n' + banner(
+                                'NOTIFICATION RESPONSE PASSED'
+                            )
                         )
                     else:
                         steps.failed(
-                            'NOTIFICATION RESPONSE FAILED:\n{0}'.format(
-                                str(notification.result)
+                            '\n' + banner(
+                                'NOTIFICATION RESPONSE FAILED:\n\n{0}'.format(
+                                    str(notification.result)
+                                )
                             )
                         )
                     notification.stop()

--- a/connector/src/yang/connector/netconf.py
+++ b/connector/src/yang/connector/netconf.py
@@ -418,21 +418,30 @@ class Netconf(manager.Manager, BaseConnection):
                 del self.active_notifications[self]
                 return
             notification.event_triggered = True
+            log.info('NOTIFICATION EVENT TRIGGERED')
             # Activate notification listener and process the notifications if any exists
             notification.start()
             while notification.time_delta < notification.stream_max:
+                log.info('WAITING FOR NOTIFICATION RESPONSE')
                 if notification.result is not None:
-                    if notification.result:
+                    if notification.result is True:
                         steps.passed(
-                            'Event triggered and notification response passed'
+                            'NOTIFICATION RESPONSE PASSED'
                         )
                     else:
                         steps.failed(
-                            'Event triggered but notification response failed'
+                            'NOTIFICATION RESPONSE FAILED:\n{0}'.format(
+                                str(notification.result)
+                            )
                         )
                     notification.stop()
                     break
                 sleep(1)
+            else:
+                steps.failed(
+                    '\n' + banner('STREAM TIMED OUT WITHOUT RESPONSE')
+                )
+                notification.stop()
 
     def configure(self, msg):
         '''configure

--- a/connector/src/yang/connector/xpath_util.py
+++ b/connector/src/yang/connector/xpath_util.py
@@ -10,6 +10,9 @@ log = logging.getLogger(__name__)
 
 def get_prefix(origin):
     # TODO: calculate a prefix instead of combining config?
+    if origin == 'openconfig':
+        # No prefix support for openconfig
+        return None
     prefix_path = proto.gnmi_pb2.Path()
     prefix_path.origin = origin
     return prefix_path


### PR DESCRIPTION
Fixes #33 

- Gnmi class method notify_wait was not finding the gnmi connection in the device.
- Notifications were passing even when response sent an error in the stream.
- No error was reported if user did not send values to verify in stream.
- No error was reported if stream timed out with no data sent in stream.
- Prefix support was being added to openconfig by mistake.
- Stream timeout value was not being sent from test to stream setup.
- No logging in Netconf notifications.