### PR TITLE
Corrected test for returning prefix path

### DIFF
--- a/connector/src/yang/connector/tests/test_gnmi.py
+++ b/connector/src/yang/connector/tests/test_gnmi.py
@@ -70,9 +70,8 @@ class TestXpathUtil(unittest.TestCase):
 
     def test_get_prefix(self):
         """Test creating a prefix Path gNMI class."""
-        path = xpath_util.get_prefix('openconfig')
+        path = xpath_util.get_prefix('rfc7951')
         self.assertIsInstance(path, proto.gnmi_pb2.Path)
-        self.assertEquals(path.origin, 'openconfig')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Openconfig does not support prefix path and rfc7951 origin cannot be duplicated in prefix path because path already has it.