### PR TITLE
Fix ImportError for gnmi

### DIFF
--- a/connector/src/yang/connector/gnmi.py
+++ b/connector/src/yang/connector/gnmi.py
@@ -1,6 +1,7 @@
 import os
 import logging
-from collections import OrderedDict, Iterable
+from collections.abc import Iterable
+from collections import OrderedDict
 import base64
 import json
 from threading import Thread, Event


### PR DESCRIPTION
Python 3.10 requires that "Iterable" now be imported directly from collections.abc instead of from collections. Before this was optional.