### PR TITLE
fixed Makefile for make develop

### DIFF
--- a/ncdiff/Makefile
+++ b/ncdiff/Makefile
@@ -83,6 +83,7 @@ develop:
 	@echo "Building and installing $(PKG_NAME) development distributable: $@"
 	@echo ""
 
+	@pip3 uninstall -y yang.ncdiff || true
 	@$(PYTHON) setup.py develop -q
 
 	@echo "Completed building and installing: $@"


### PR DESCRIPTION
`make develop` for ncdiff is different with others. added uninstalling package before making develop mode.