### PR TITLE
Tahigash ver pinning fix

### DIFF
--- a/connector/docs/changelog/undistributed/changelog_tahigash_pinning_protobuf_20220630142700.rst
+++ b/connector/docs/changelog/undistributed/changelog_tahigash_pinning_protobuf_20220630142700.rst
@@ -1,0 +1,7 @@
+
+--------------------------------------------------------------------------------
+                                Fix
+--------------------------------------------------------------------------------
+* yang.connector
+    * Modified setup.py:
+        * Update version pinning for protobuf depending on python version

--- a/connector/setup.py
+++ b/connector/setup.py
@@ -184,7 +184,8 @@ setup(
         'ncclient >= 0.6.6',
         'grpcio',
         'cisco-gnmi >= 1.0.13',
-        'protobuf ~= 3.20',
+        'protobuf ~= 3.20;python_version>="3.7"',
+        'protobuf < 3.20;python_version<"3.7"',
     ],
 
     # any additional groups of dependencies.

--- a/connector/src/yang/connector/__init__.py
+++ b/connector/src/yang/connector/__init__.py
@@ -7,7 +7,7 @@ Restconf implementation is coming next.
 """
 
 # metadata
-__version__ = '22.6'
+__version__ = '22.6.2'
 __author__ = (
     'Jonathan Yang <yuekyang@cisco.com>',
     'Siming Yuan <siyuan@cisco.com',


### PR DESCRIPTION
users who use python3.6 encountered version mismatch issue with yang.connector due to protobuf after upgrading to 22.6. needed to add to pin protobuf depending on python version.