### PR TITLE
removed cisco-gnmi dependency

### DIFF
--- a/connector/setup.py
+++ b/connector/setup.py
@@ -183,7 +183,6 @@ setup(
         'lxml >= 3.3.0',
         'ncclient >= 0.6.6',
         'grpcio',
-        'cisco-gnmi >= 1.0.13',
         'protobuf ~= 3.20;python_version>="3.7"',
         'protobuf < 3.20;python_version<"3.7"',
     ],

--- a/ncdiff/setup.py
+++ b/ncdiff/setup.py
@@ -172,7 +172,6 @@ setup(
         'pyang >= 1.7.3',
         'ncclient >= 0.6.3',
         'requests >= 2.18.4',
-        'cisco-gnmi',
         'xmljson >= 0.1.9',
         'yang.connector >= 3.0.0',
     ],


### PR DESCRIPTION
I believe cisco-gnmi by [PR74](https://github.com/CiscoTestAutomation/yang/pull/74) is no longer needed. and now proto is conflicting with it. so removing the dependency.