### PR TITLE
Added locked function to NetconfEnxr class.

### DIFF
--- a/connector/src/yang/connector/netconf.py
+++ b/connector/src/yang/connector/netconf.py
@@ -960,6 +960,23 @@ class NetconfEnxr():
         unlock_element.append(target_element)
         return self.send_cmd(self.get_rpc(unlock_element))
 
+    class LockContext:
+        def __init__(self, target, cls):
+            self.cls = cls
+            self.target = target
+
+        def __enter__(self):
+            self.cls.lock(self.target)
+            return self
+
+        def __exit__(self, *args):
+            self.cls.unlock(self.target)
+            return False
+
+    def locked(self, target):
+        '''Return a lock context manager for EnXR'''
+        return self.LockContext(target, self)
+
     def dispatch(self, rpc_command=None, **kwargs):
         rpc = rpc_command
         return self.send_cmd(rpc)


### PR DESCRIPTION
Fixes #85 .

NetconfEnxr class mimics ncclient manager except it uses unix sockets for transfer instead of network connections.  New yang_snapshot_restore action uses manager.locked context manager.  This change adds a lock context manager.  EnXR does not really need to lock the datastore but for consistency, the logs will show that locks and unlocks occur.

Testing:
```
>>> import logging
>>> logger = logging.getLogger('enxr')
>>> logger.setLevel(logging.DEBUG)
>>> logging.basicConfig(level=logging.DEBUG)
>>> from yang.connector import NetconfEnxr
>>> nc=NetconfEnxr()
>>> with nc.locked('running'):
...     print('mike')
... 
INFO:yang.connector.netconf:Not connected.
mike
INFO:yang.connector.netconf:Not connected.
>>>
```