### PR TITLE
Remove requirement of pyats libraries.

### DIFF
--- a/connector/docs/changelog/undistributed/changelog_remove_depend_2305051228.rst
+++ b/connector/docs/changelog/undistributed/changelog_remove_depend_2305051228.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                                Fix
+--------------------------------------------------------------------------------
+* connector
+    * Removed dependency of installing pyats to use connector classes.
+        * Try/except in settings.py around AttrDict.

--- a/connector/docs/changelog/undistributed/changelog_remove_depend_2305051228.rst
+++ b/connector/docs/changelog/undistributed/changelog_remove_depend_2305051228.rst
@@ -3,4 +3,4 @@
 --------------------------------------------------------------------------------
 * connector
     * Removed dependency of installing pyats to use connector classes.
-        * Try/except in settings.py around AttrDict.
+        * Settings class in settings.py now subclasses dict instead of AttrDict.

--- a/connector/src/yang/connector/settings.py
+++ b/connector/src/yang/connector/settings.py
@@ -1,5 +1,9 @@
+try:
+    from pyats.datastructures import AttrDict
+except ImportError:
+    class AttrDict:
+        pass
 
-from pyats.datastructures import AttrDict
 
 class Settings(AttrDict):
 

--- a/connector/src/yang/connector/settings.py
+++ b/connector/src/yang/connector/settings.py
@@ -8,8 +8,3 @@ class Settings(dict):
         self.NETCONF_SCREEN_LOGGING_MAX_LINES = 40
         # Enable XML formatting by default
         self.NETCONF_LOGGING_FORMAT_XML = True
-
-    def __repr__(self):
-        return '%s(%s)' % (self.__class__.__name__,
-                        super(AttrDict, self).__repr__())
-

--- a/connector/src/yang/connector/settings.py
+++ b/connector/src/yang/connector/settings.py
@@ -1,14 +1,15 @@
-try:
-    from pyats.datastructures import AttrDict
-except ImportError:
-    class AttrDict:
-        pass
 
+class Settings(dict):
 
-class Settings(AttrDict):
-
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__dict__ = self
         # Default number of lines to log to screen
         self.NETCONF_SCREEN_LOGGING_MAX_LINES = 40
         # Enable XML formatting by default
         self.NETCONF_LOGGING_FORMAT_XML = True
+
+    def __repr__(self):
+        return '%s(%s)' % (self.__class__.__name__,
+                        super(AttrDict, self).__repr__())
+


### PR DESCRIPTION
#88 yang.connector classes can be imported and used by other libraries without having to install the entire pyats library.  This simple change will allow that.