### PR TITLE
Allow 'ip' host key for GNMI connections

### DIFF
--- a/connector/docs/changelog/undistributed/changelog_update_gnmi_06222023.rst
+++ b/connector/docs/changelog/undistributed/changelog_update_gnmi_06222023.rst
@@ -2,5 +2,5 @@
                                 Fix
 --------------------------------------------------------------------------------
 * yang.connector
-    * Modified protofiles:
-        * Recompiled gnmi protofiles to upgrade protobuf dependency to latest
+    * Modified Gnmi object:
+        * Added support for Host address keying by 'ip'

--- a/connector/docs/changelog/undistributed/changelog_update_protofiles_06162023.rst
+++ b/connector/docs/changelog/undistributed/changelog_update_protofiles_06162023.rst
@@ -4,5 +4,5 @@
 * yang.connector
     * Modified protofiles:
         * Recompiled gnmi protofiles to upgrade protobuf dependency to latest
-    * Modified Gnmi object
+    * Modified Gnmi object:
         * Added support for Host address keying by 'ip'

--- a/connector/docs/changelog/undistributed/changelog_update_protofiles_06162023.rst
+++ b/connector/docs/changelog/undistributed/changelog_update_protofiles_06162023.rst
@@ -4,3 +4,5 @@
 * yang.connector
     * Modified protofiles:
         * Recompiled gnmi protofiles to upgrade protobuf dependency to latest
+    * Modified Gnmi object
+        * Added support for Host address keying by 'ip'

--- a/connector/src/yang/connector/gnmi.py
+++ b/connector/src/yang/connector/gnmi.py
@@ -264,11 +264,10 @@ class Gnmi(BaseConnection):
                 raise KeyError('No credentials found for gNMI testbed')
         password = to_plaintext(password)
 
+        host = dev_args.get('host') or dev_args.get('ip')
         port = str(dev_args.get('port'))
-        target = '{0}:{1}'.format(
-            dev_args.get('host'),
-            port
-        )
+        target = '{0}:{1}'.format(host, port)
+
         options = [('grpc.max_receive_message_length', 1000000000)]
         # Gather certificate settings
         root = dev_args.get('root_certificate')


### PR DESCRIPTION
If a GNMI connection has its IP address defined under 'ip' then the connection fails to establish. This change allows use of either 'host' or 'ip'