### PR TITLE
Add ssh tunnel to gnmi

### DIFF
--- a/connector/src/yang/connector/gnmi.py
+++ b/connector/src/yang/connector/gnmi.py
@@ -7,6 +7,8 @@ from google.protobuf import json_format
 import grpc
 from . import proto
 
+from unicon.sshutils import sshtunnel
+
 try:
     from pyats.log.utils import banner
     from pyats.connections import BaseConnection
@@ -264,7 +266,6 @@ class Gnmi(BaseConnection):
                 raise KeyError('No credentials found for gNMI testbed')
         password = to_plaintext(password)
         if 'sshtunnel' in dev_args:
-            from unicon.sshutils import sshtunnel
             try:
                 tunnel_port = sshtunnel.auto_tunnel_add(self.device, self.via)
                 if tunnel_port:

--- a/connector/src/yang/connector/gnmi.py
+++ b/connector/src/yang/connector/gnmi.py
@@ -263,9 +263,21 @@ class Gnmi(BaseConnection):
             if not username or not password:
                 raise KeyError('No credentials found for gNMI testbed')
         password = to_plaintext(password)
-
-        host = dev_args.get('host') or dev_args.get('ip')
-        port = str(dev_args.get('port'))
+        if 'sshtunnel' in dev_args:
+            from unicon.sshutils import sshtunnel
+            try:
+                tunnel_port = sshtunnel.auto_tunnel_add(self.device, self.via)
+                if tunnel_port:
+                    host = self.device.connections[self.via] \
+                                           .sshtunnel.tunnel_ip
+                    port = tunnel_port
+            except AttributeError as err:
+                raise AttributeError("Cannot add ssh tunnel. \
+                Connection %s may not have ip/host or port.\n%s"
+                                     % (self.via, err))
+        else:
+            host = dev_args.get('host') or dev_args.get('ip')
+            port = str(dev_args.get('port'))
         target = '{0}:{1}'.format(host, port)
 
         options = [('grpc.max_receive_message_length', 1000000000)]

--- a/connector/src/yang/connector/tests/test_gnmi.py
+++ b/connector/src/yang/connector/tests/test_gnmi.py
@@ -1,11 +1,73 @@
 import unittest
+from unittest.mock import Mock, MagicMock, patch
 
 from yang.connector import proto
+from yang.connector import gnmi
 from yang.connector import xpath_util
 
+from pyats.topology import loader
+from pyats.datastructures import AttrDict
 
-class TestXpathUtil(unittest.TestCase):
 
+class TestGnmi(unittest.TestCase):
+
+
+    def test_connect(self):
+
+        yaml = \
+            'devices:\n' \
+            '    dummy:\n' \
+            '        type: dummy_device\n' \
+            '        connections:\n' \
+            '            Gnmi:\n' \
+            '                class:  yang.connector.Gnmi\n' \
+            '                protocol: gnmi\n' \
+            '                ip : "1.2.3.4"\n' \
+            '                port: 830\n' \
+            '                username: admin\n' \
+            '                password: admin\n'
+
+        testbed = loader.load(yaml)
+        device = testbed.devices['dummy']
+        with patch('yang.connector.gnmi.grpc.insecure_channel') as mock_grpc:
+            device.connect(alias='gnmi', via='Gnmi')
+            mock_grpc.assert_called_with('1.2.3.4:830')
+
+    def test_connect_proxy(self):
+        yaml = \
+            'devices:\n' \
+            '    dummy:\n' \
+            '        type: proxy_device\n' \
+            '        connections:\n' \
+            '           defaults:\n' \
+            '                class:  unicon.Unicon\n' \
+            '           ssh:\n' \
+            '                ip : "4.3.2.1"\n' \
+            '                port: 22\n' \
+            '                ssh_options: -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\n' \
+            '                password: admin\n' \
+            '    dummy:\n' \
+            '        type: dummy_device\n' \
+            '        connections:\n' \
+            '            Gnmi:\n' \
+            '                class:  yang.connector.Gnmi\n' \
+            '                protocol: gnmi\n' \
+            '                ip : "1.2.3.4"\n' \
+            '                port: 830\n' \
+            '                username: admin\n' \
+            '                password: admin\n' \
+            '                sshtunnel:\n' \
+            '                  host: jumphost\n'\
+            '                  tunnel_ip: 830\n' \
+
+        testbed = loader.load(yaml)
+        device = testbed.devices['dummy']
+        with patch('yang.connector.gnmi.sshtunnel.auto_tunnel_add') as mock_tunnel:
+            with patch('yang.connector.gnmi.grpc.insecure_channel') as mock_grpc:
+                mock_tunnel.side_effect = ['830']
+                device.connections['Gnmi'].sshtunnel = AttrDict({'tunnel_ip': '4.3.2.1'})
+                device.connect(alias='gnmi', via='Gnmi')
+                mock_grpc.assert_called_with('4.3.2.1:830')
     request = {
         "namespace": {"oc-acl": "http://openconfig.net/yang/acl"},
         "nodes": [


### PR DESCRIPTION
Add ssh tunnel for gnmi connection
```
>>> dev =testbed.devices['ott-c9300-68']
>>> dev.connect(alias='gnmi', via='yang2')
Credentials used from default
2023-09-21T15:56:37: %UNICON-INFO: Connecting proxy host proxy
Connecting proxy host proxy

2023-09-21 15:56:37,338: %UNICON-INFO: +++ proxy logfile /tmp/proxy-20230921T155637336.log +++

2023-09-21 15:56:37,339: %UNICON-INFO: +++ Unicon plugin linux (unicon.internal.plugins.linux) +++

2023-09-21 15:56:37,344: %UNICON-INFO: +++ connection to spawn: ssh -l proxyuser1 10.85.17.87, id: 4566357472 +++

2023-09-21 15:56:37,345: %UNICON-INFO: connection to proxy
This is a Cisco managed device to be used only for authorized purposes. 
Your use is monitored for security, asset protection, and policy compliance.

proxyuser1@10.85.17.87's password: 
Cisco Linux 8.2-8Devsuite Kickstarted on: Wed Mar 24 10:49:42 PDT 2021.
Activate the web console with: systemctl enable --now cockpit.socket

Last login: Thu Sep 21 11:28:58 2023 from 161.44.236.16
Cisco Linux 8.2-8Devsuite Kickstarted on: Wed Mar 24 10:49:42 PDT 2021.
[proxyuser1@ott1lab-tun-lnx ~]$ 

2023-09-21 15:56:37,906: %UNICON-INFO: +++ initializing handle +++

2023-09-21 15:56:37,907: %UNICON-INFO: +++ log_user: disable +++
2023-09-21T15:56:37: %UNICON-INFO: Adding local tunnel 127.0.0.1:20002 for 5.40.13.68:50052
Adding local tunnel 127.0.0.1:20002 for 5.40.13.68:50052
2023-09-21T15:56:38: %UNICON-INFO: Device 'ott-c9300-68' connection 'yang2' via new SSH tunnel 127.0.0.1:20002
Device 'ott-c9300-68' connection 'yang2' via new SSH tunnel 127.0.0.1:20002
Connecting insecure channel

gNMI version: 0.7.0 supported encodings: ['JSON', 'JSON_IETF', 'PROTO']


+------------------------------------------------------------------------------+
|                                gNMI CONNECTED                                |
```