### PR TITLE
Need conditional imports for pyats and unicon to use yang.connector without pyats installed.

### DIFF
--- a/connector/src/yang/connector/gnmi.py
+++ b/connector/src/yang/connector/gnmi.py
@@ -7,12 +7,12 @@ from google.protobuf import json_format
 import grpc
 from . import proto
 
-from unicon.sshutils import sshtunnel
 
 try:
     from pyats.log.utils import banner
     from pyats.connections import BaseConnection
     from pyats.utils.secret_strings import to_plaintext
+    from unicon.sshutils import sshtunnel
 except ImportError:
     # Standalone without pyats install
     class BaseConnection:
@@ -30,6 +30,7 @@ except ImportError:
 
     def to_plaintext(string):
         return string
+
 
 # create a logger for this module
 log = logging.getLogger(__name__)

--- a/connector/src/yang/connector/grpc/__init__.py
+++ b/connector/src/yang/connector/grpc/__init__.py
@@ -3,8 +3,14 @@ import tempfile
 from importlib import import_module
 from shutil import copyfile
 
-from pyats.connections import BaseConnection
-from pyats.easypy import runtime
+try:
+    from pyats.connections import BaseConnection
+    from pyats.easypy import runtime
+except ImportError:
+    class BaseConnection:
+        pass
+    class runtime:
+        pass
 
 # create a logger for this module
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Added conditional imports for yang.connector because user should be able to use library without installing pyats.