### PR TITLE
Fix no module error

### DIFF
--- a/ncdiff/src/yang/ncdiff/tests/test_running_config.py
+++ b/ncdiff/src/yang/ncdiff/tests/test_running_config.py
@@ -2,7 +2,7 @@
 """ Unit tests for the ncdiff cisco-shared package. """
 
 import unittest
-from ncdiff import RunningConfigDiff
+from yang.ncdiff import RunningConfigDiff
 
 
 class TestRunningConfig(unittest.TestCase):


### PR DESCRIPTION
Fix the below error,

```
ImportError: Failed to import test module: test_running_config
Traceback (most recent call last):
  File "xxx/unittest/loader.py", line 129, in loadTestsFromName
    module = __import__(module_name)
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "xxx/yang/ncdiff/src/yang/ncdiff/tests/test_running_config.py", line 5, in <module>
    from ncdiff import RunningConfigDiff
ModuleNotFoundError: No module named 'ncdiff'

```