### PR TITLE
added keepalive to fix timeout/connection reset issue

### DIFF
--- a/connector/src/yang/connector/netconf.py
+++ b/connector/src/yang/connector/netconf.py
@@ -501,6 +501,7 @@ class Netconf(manager.Manager, BaseConnection):
             'hostkey_verify': False,
             'look_for_keys': False,
             'ssh_config': None,
+            'keepalive': False,
             }
         defaults.update(self.connection_info)
 


### PR DESCRIPTION
To get rid of timeout/connection reset over netconf connection, added `keepalive` to keep connection alive as mentioned in here: https://github.com/ncclient/ncclient/blob/master/ncclient/transport/ssh.py#L210