### PR TITLE
Chenges

### DIFF
--- a/ncdiff/src/yang/ncdiff/runningconfig.py
+++ b/ncdiff/src/yang/ncdiff/runningconfig.py
@@ -93,6 +93,7 @@ ORDERLESS_COMMANDS = [
     (re.compile(r'^ *redistribute '), 2),
     (re.compile(r'^ *redistribute '), 3),
     (re.compile(r'^ *distribute-list '), 1),
+    (re.compile(r'^ *device-tracking binding '), 0),
 ]
 
 # Some commands can be overwritten without a no command. For example, changing


### PR DESCRIPTION
updated orderless config like below device-tracking binding at depth 0.
`device-tracking binding 2035:DB8::/32 interface GigabitEthernet1/0/1 10b3.d529.3d69 tracking disable`

https://wwwin-github.cisco.com/pyATS/support/issues/6600