### PR TITLE
Passing values to preferred_create, preferred_replace and preferred_delete parameters while creating ConfigDelta object

### DIFF
--- a/ncdiff/docs/changelog/changelog_modify_ConfigDelta_20240828235821.rst
+++ b/ncdiff/docs/changelog/changelog_modify_ConfigDelta_20240828235821.rst
@@ -1,0 +1,7 @@
+--------------------------------------------------------------------------------
+                                Fix
+--------------------------------------------------------------------------------
+* yang.ncdiff
+    * Modified ConfigDelta:
+        * Updated __neg__ to pass default values of preferred_create, preferred_replace and preferred_delete while creating ConfigDelta object
+

--- a/ncdiff/src/yang/ncdiff/config.py
+++ b/ncdiff/src/yang/ncdiff/config.py
@@ -598,7 +598,10 @@ class ConfigDelta(object):
 
     def __neg__(self):
         return ConfigDelta(config_src=self.config_dst,
-                           config_dst=self.config_src)
+                           config_dst=self.config_src,
+                           preferred_create=self.preferred_create,
+                           preferred_replace=self.preferred_replace,
+                           preferred_delete=self.preferred_delete)
 
     def __pos__(self):
         return self


### PR DESCRIPTION
## Description

Passing values to `preferred_create`, `preferred_replace` and `preferred_delete` parameters while creating `ConfigDelta` object in `src/yang/ncdiff/config.py#L599` while returning negation of `ConfigDelta` object.

The user is passing values for `preferred_create`, `preferred_replace` and `preferred_delete` parameters while creating the `ConfigDelta` object. But the negation of the same `ConfigDelta` object is returning the another `ConfigDelta` object but with the default values set for `preferred_create`, `preferred_replace` and `preferred_delete` attributes instead of what user passed to create the original `ConfigDelta` object. 

For example:

Without this fix, the negation of `ConfigDelta` object looked like this when `preferred_delete` passed as `replace` to original `ConfigDelta` object:
```
<nc:config xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
    <native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
		<snmp-server nc:operation="delete"/>
	</native>
</nc:config>
```
But as per user, it should take the `operation` as `replace` because this is what the value is being passed by the user to `preferred_delete` parameter while creating the original `ConfigDelta` object.

With this fix, the negation of `ConfigDelta` object looked like this when `preferred_delete` passed as `replace` to original `ConfigDelta` object:
```
<nc:config xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
	<native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
		<snmp-server nc:operation="replace"/>
	</native>
</nc:config>
```