### PR TITLE
Updated documentation related to gnmi connection

### DIFF
--- a/ncdiff/docs/usage_gnmi_set.rst
+++ b/ncdiff/docs/usage_gnmi_set.rst
@@ -27,6 +27,8 @@ YAML topology file:
                 enable: admin
                 line: admin
             connections:
+                defaults:
+                    class: unicon.Unicon
                 a:
                     protocol: telnet
                     ip: "1.2.3.4"
@@ -35,7 +37,8 @@ YAML topology file:
                     protocol : telnet
                     ip : "2.3.4.5"
                 gnmi:
-                    class: yang.connector.gNMI
+                    class: yang.connector.Gnmi
+                    protocol: gnmi
                     ip : "2.3.4.5"
                     port: 50052
                     timeout: 10


### PR DESCRIPTION
Modified gnmi connection details in testbed to use valid gnmi class: `yang.connector.Gnmi` and added mandatory `protocol` attribute with value as `gnmi`.