### PR TITLE
Consider default in use

### DIFF
--- a/ncdiff/src/yang/ncdiff/device.py
+++ b/ncdiff/src/yang/ncdiff/device.py
@@ -726,6 +726,77 @@ class ModelDevice(Netconf):
 
         return Composer(self, node).get_xpath(type, instance=instance)
 
+    def default_in_use(self, schema_node):
+        '''
+        High-level api: Given a schema node, return a list of schema nodes
+        that are descendants and their default values are in use, if the given
+        schema node exists in a data tree. This method is useful to determine
+        if a default value for a leaf or leaf-list is in use in a data tree.
+        Parameters
+        ----------
+        schema_node : `Element`
+            A schema node in question.
+        Returns
+        -------
+        list
+            A list of schema nodes that are descendants of the given schema
+            node and their default values are in use if the given schema node
+            exists in a data tree. If such schema node does not exist, it
+            returns an empty list.
+        Code Example::
+            >>> m.load_model('openconfig-interfaces')
+            >>> prefixes = {n[1]: n[2] for n in m.namespaces}
+            >>> nodes = m.models["openconfig-interfaces"].tree.xpath(
+                    "//oc-if:interfaces/oc-if:interface",
+                    namespaces=prefixes,
+                )
+            >>> print(nodes)
+            [<Element {http://openconfig.net/yang/interfaces}interface at 0x7ff632320ac0>]
+            >>> defaults = m.default_in_use(nodes[0])
+            >>> print([m.get_xpath(n) for n in defaults])
+            ...
+        '''
+
+        default_nodes = []
+        for child in schema_node:
+            if (
+                child.get('type') in ('leaf', 'leaf-list') and
+                child.get('default') is not None
+            ):
+                default_nodes.append(child)
+            elif (
+                child.get('type') == 'choice' and
+                child.get('default') is not None
+            ):
+                default_case = child.get('default')
+                default_ns, _ = self.convert_tag(
+                    default_ns='',
+                    tag=child.tag,
+                    src=Tag.LXML_ETREE,
+                    dst=Tag.LXML_XPATH,
+                )
+                default_ns = self.convert_ns(
+                    ns=default_ns,
+                    src=Tag.NAMESPACE,
+                    dst=Tag.PREFIX,
+                )
+                _, tag = self.convert_tag(
+                    default_ns=default_ns,
+                    tag=default_case,
+                    src=Tag.XPATH,
+                    dst=Tag.LXML_ETREE,
+                )
+                default_case_node = child.find(tag)
+                if default_case_node is not None:
+                    default_nodes.append(default_case_node)
+                    default_nodes += self.default_in_use(default_case_node)
+            elif (
+                child.get('type') == 'container' and
+                child.get('presence') != 'true'
+            ):
+                default_nodes += self.default_in_use(child)
+        return default_nodes
+
     def convert_tag(self, default_ns, tag, src=Tag.LXML_ETREE, dst=Tag.YTOOL):
         '''convert_tag
 

--- a/ncdiff/src/yang/ncdiff/tests/test_ncdiff.py
+++ b/ncdiff/src/yang/ncdiff/tests/test_ncdiff.py
@@ -1367,6 +1367,136 @@ class TestNcDiff(unittest.TestCase):
         self.assertEqual(str(delta1).strip(), expected_delta1.strip())
         self.assertEqual(str(delta2).strip(), expected_delta2.strip())
 
+    def test_delta_11(self):
+        xml1 = """
+            <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+              <data>
+                <numbers xmlns="urn:jon">
+                  <first>one</first>
+                </numbers>
+                <location xmlns="urn:jon">
+                  <ontario>
+                    <name>Ottawa</name>
+                  </ontario>
+                </location>
+              </data>
+            </rpc-reply>
+            """
+        xml2 = """
+            <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+              <data>
+                <numbers xmlns="urn:jon">
+                  <first>one</first>
+                  <third>three</third>
+                </numbers>
+                <location xmlns="urn:jon">
+                  <alberta>
+                    <name>Calgary</name>
+                  </alberta>
+                  <other-info>
+                    <detail>Some detail</detail>
+                  </other-info>
+                </location>
+              </data>
+            </rpc-reply>
+            """
+        config1 = Config(self.d, xml1)
+        config2 = Config(self.d, xml2)
+        delta1 = config2 - config1
+        delta2 = config1 - config2
+        delta1.preferred_create = "create"
+        delta2.preferred_create = "create"
+        verification = [
+            (delta1, "/nc:config/jon:numbers/jon:third"),
+
+            # Create operation at list alberta is allowed as it does not have
+            # default.
+            (delta1, "/nc:config/jon:location/jon:alberta"),
+
+            # Create operation at other-info is not allowed as it has defaults.
+            (delta1, "/nc:config/jon:location/jon:other-info/jon:detail"),
+
+            (delta2, "/nc:config/jon:location/jon:ontario"),
+        ]
+        for delta, xpath in verification:
+            nodes = delta.nc.xpath(
+                xpath,
+                namespaces=delta.ns)
+            self.assertEqual(
+                len(nodes),
+                1,
+                f"Expected to find xpath '{xpath}' in delta "
+                f"but the delta is {delta.nc}",
+            )
+            for node in nodes:
+                self.assertEqual(
+                    node.get(operation_tag),
+                    "create",
+                    f"Expected 'create' operation at {xpath} "
+                    f"but got the delta {delta.nc} instead.",
+                )
+
+    def test_delta_12(self):
+        xml1 = """
+            <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+              <data>
+                <numbers xmlns="urn:jon">
+                  <first>one</first>
+                </numbers>
+              </data>
+            </rpc-reply>
+            """
+        xml2 = """
+            <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+              <data>
+                <numbers xmlns="urn:jon">
+                  <first>one</first>
+                  <third>three</third>
+                </numbers>
+                <location xmlns="urn:jon">
+                  <alberta>
+                    <name>Calgary</name>
+                  </alberta>
+                  <other-info>
+                    <detail>Some detail</detail>
+                  </other-info>
+                </location>
+              </data>
+            </rpc-reply>
+            """
+        config1 = Config(self.d, xml1)
+        config2 = Config(self.d, xml2)
+        delta1 = config2 - config1
+        delta2 = config1 - config2
+        delta1.preferred_create = "create"
+        delta2.preferred_create = "create"
+        verification = [
+            (delta1, "/nc:config/jon:numbers/jon:third"),
+
+            # Create operation at location is not allowed as it has defaults.
+            (delta1, "/nc:config/jon:location/jon:alberta"),
+
+            # Create operation at other-info is not allowed as it has defaults.
+            (delta1, "/nc:config/jon:location/jon:other-info/jon:detail"),
+        ]
+        for delta, xpath in verification:
+            nodes = delta.nc.xpath(
+                xpath,
+                namespaces=delta.ns)
+            self.assertEqual(
+                len(nodes),
+                1,
+                f"Expected to find xpath '{xpath}' in delta "
+                f"but the delta is {delta.nc}",
+            )
+            for node in nodes:
+                self.assertEqual(
+                    node.get(operation_tag),
+                    "create",
+                    f"Expected 'create' operation at {xpath} "
+                    f"but got the delta {delta.nc} instead.",
+                )
+
     def test_delta_replace_1(self):
         config_xml1 = """
             <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
@@ -4512,3 +4642,65 @@ class TestNcDiff(unittest.TestCase):
                        '/oc-netinst:config/oc-netinst:name/text()')
         self.assertEqual(name, ['Mgmt-intf'])
 
+    def test_default_in_use_1(self):
+      prefixes = {n[1]: n[2] for n in self.d.namespaces}
+      nodes = self.d.models["jon"].tree.xpath(
+          "/jon/jon:address",
+          namespaces=prefixes,
+      )
+      self.assertEqual(len(nodes), 1)
+      address = nodes[0]
+      defaults = self.d.default_in_use(address)
+      self.assertEqual(len(defaults), 1)
+      self.assertEqual(
+          defaults[0].tag,
+          "{urn:jon}city"
+      )
+
+    def test_default_in_use_2(self):
+      xpaths = [
+          "/jon:location/city/alberta",
+          "/jon:location/city/alberta/other-info/geo-facts/code",
+      ]
+      prefixes = {n[1]: n[2] for n in self.d.namespaces}
+      nodes = self.d.models["jon"].tree.xpath(
+          "/jon/jon:location",
+          namespaces=prefixes,
+      )
+      self.assertEqual(len(nodes), 1)
+      address = nodes[0]
+      defaults = self.d.default_in_use(address)
+      xpaths = [
+          self.d.get_xpath(n)
+          for n in defaults
+      ]
+      self.assertEqual(len(defaults), 2)
+      for xpath in xpaths:
+          self.assertIn(xpath, xpaths)
+
+    def test_default_in_use_3(self):
+      xpaths = [
+          "/oc-if:interfaces/interface/oc-vlan:routed-vlan/oc-ip:ipv4"
+          "/unnumbered/config/enabled",
+          "/oc-if:interfaces/interface/oc-vlan:routed-vlan/oc-ip:ipv4"
+          "/unnumbered/state/enabled",
+          "/oc-if:interfaces/interface/oc-vlan:routed-vlan/oc-ip:ipv4"
+          "/config/enabled",
+          "/oc-if:interfaces/interface/oc-vlan:routed-vlan/oc-ip:ipv4"
+          "/state/enabled",
+      ]
+      prefixes = {n[1]: n[2] for n in self.d.namespaces}
+      nodes = self.d.models["openconfig-interfaces"].tree.xpath(
+          "//oc-if:interfaces/oc-if:interface/oc-vlan:routed-vlan/oc-ip:ipv4",
+          namespaces=prefixes,
+      )
+      self.assertEqual(len(nodes), 1)
+      interface = nodes[0]
+      defaults = self.d.default_in_use(interface)
+      xpaths = [
+          self.d.get_xpath(n)
+          for n in defaults
+      ]
+      self.assertEqual(len(defaults), 4)
+      for xpath in xpaths:
+          self.assertIn(xpath, xpaths)

--- a/ncdiff/src/yang/ncdiff/tests/test_ncdiff.py
+++ b/ncdiff/src/yang/ncdiff/tests/test_ncdiff.py
@@ -4643,7 +4643,7 @@ class TestNcDiff(unittest.TestCase):
         self.assertEqual(name, ['Mgmt-intf'])
 
     def test_default_in_use_1(self):
-      prefixes = {n[1]: n[2] for n in self.d.namespaces}
+      prefixes = {n[1]: n[2] for n in self.d.namespaces if n[1] is not None}
       nodes = self.d.models["jon"].tree.xpath(
           "/jon/jon:address",
           namespaces=prefixes,
@@ -4662,7 +4662,7 @@ class TestNcDiff(unittest.TestCase):
           "/jon:location/city/alberta",
           "/jon:location/city/alberta/other-info/geo-facts/code",
       ]
-      prefixes = {n[1]: n[2] for n in self.d.namespaces}
+      prefixes = {n[1]: n[2] for n in self.d.namespaces if n[1] is not None}
       nodes = self.d.models["jon"].tree.xpath(
           "/jon/jon:location",
           namespaces=prefixes,
@@ -4689,7 +4689,7 @@ class TestNcDiff(unittest.TestCase):
           "/oc-if:interfaces/interface/oc-vlan:routed-vlan/oc-ip:ipv4"
           "/state/enabled",
       ]
-      prefixes = {n[1]: n[2] for n in self.d.namespaces}
+      prefixes = {n[1]: n[2] for n in self.d.namespaces if n[1] is not None}
       nodes = self.d.models["openconfig-interfaces"].tree.xpath(
           "//oc-if:interfaces/oc-if:interface/oc-vlan:routed-vlan/oc-ip:ipv4",
           namespaces=prefixes,

--- a/ncdiff/src/yang/ncdiff/tests/yang/jon.yang
+++ b/ncdiff/src/yang/ncdiff/tests/yang/jon.yang
@@ -7,6 +7,11 @@ module jon {
       "Initial revision";
   }
 
+  revision 2025-04-02 {
+    description
+      "Deprecated two nodes";
+  }
+
   leaf foo {
     type string;
   }
@@ -14,6 +19,24 @@ module jon {
   container tracking {
     leaf enabled {
       type boolean;
+      default "false"; /* Deprecated, use 'enabled-v2' instead */
+      status deprecated; /* Marked as deprecated in the 2025-04-02 revision */
+    }
+    leaf enabled-v2 {
+      type boolean;
+    }
+    container logging {
+      leaf local {
+        type boolean;
+      }
+      container server {
+        leaf host {
+          type string;
+        }
+        leaf port {
+          type uint16;
+        }
+      }
     }
   }
 
@@ -35,6 +58,12 @@ module jon {
     leaf city {
       type string;
       description "City name";
+      default "Unknown"; /* Deprecated, use 'city-v2' instead */
+      status deprecated; /* Marked as deprecated in the 2025-04-02 revision */
+    }
+    leaf city-v2 {
+      type string;
+      description "City name";
     }
   }
 
@@ -45,6 +74,7 @@ module jon {
 
   container location {
     choice city {
+      default alberta;
       case ontario {
         list ontario {
           key "name";
@@ -58,6 +88,27 @@ module jon {
           key "name";
           leaf name {
             type string;
+          }
+        }
+        container other-info {
+          leaf detail {
+            type string;
+            description "Additional information about Alberta.";
+          }
+          container geo-facts {
+            leaf area {
+              type int16;
+              description "Area of Alberta.";
+            }
+            leaf population {
+              type int16;
+              description "Population of Alberta.";
+            }
+            leaf code {
+              type string;
+              description "Code for Alberta.";
+              default "AB";
+            }
           }
         }
       }


### PR DESCRIPTION
Normally, it's okay to use 'create' operation on a node when it does not exist in a configuration data tree. However, if there are default values in use, 'create' operation could be invalid. The PR fixes this scenario when generating Netconf edit-config.

Unit tests are added.

```
(pyats-2401) [yuekyang@yangtest-lnx tests]$ python -m unittest test_ncdiff
Error in Netconf reply when getting /netconf-state/schemas from YANG module 'ietf-netconf-monitoring':
<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
  <rpc-error>
    <error-type>rpc</error-type>
    <error-tag>missing-attribute</error-tag>
    <error-severity>error</error-severity>
    <error-info>
      <bad-attribute>message-id</bad-attribute>
      <bad-element>rpc</bad-element>
    </error-info>
  </rpc-error>
</rpc-reply>

Error in Netconf reply when getting /modules-state/module from YANG module 'ietf-yang-library':
<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
  <rpc-error>
    <error-type>rpc</error-type>
    <error-tag>missing-attribute</error-tag>
    <error-severity>error</error-severity>
    <error-info>
      <bad-attribute>message-id</bad-attribute>
      <bad-element>rpc</bad-element>
    </error-info>
  </rpc-error>
</rpc-reply>

........................................
----------------------------------------------------------------------
Ran 40 tests in 0.593s

OK
(pyats-2401) [yuekyang@yangtest-lnx tests]$ python -m unittest test_running_config
...........................................
----------------------------------------------------------------------
Ran 43 tests in 0.030s

OK
(pyats-2401) [yuekyang@yangtest-lnx tests]$
```