### PR TITLE
Avoid create operation on NP containers

### DIFF
--- a/ncdiff/docs/changelog/undistributed/np_containers.rst
+++ b/ncdiff/docs/changelog/undistributed/np_containers.rst
@@ -1,0 +1,5 @@
+--------------------------------------------------------------------------------
+                                Fixes
+--------------------------------------------------------------------------------
+* yang.ncdiff
+    * Modified ConfigDelta to avoid 'create' and 'delete' operations on non-presence containers.

--- a/ncdiff/src/yang/ncdiff/netconf.py
+++ b/ncdiff/src/yang/ncdiff/netconf.py
@@ -352,7 +352,6 @@ class NetconfCalculator(BaseCalculator):
 
         for child_other in in_o_not_in_s:
             child_self = etree.Element(child_other.tag,
-                                       {operation_tag: self.preferred_delete},
                                        nsmap=child_other.nsmap)
             siblings = list(node_self.iterchildren(tag=child_other.tag))
             if siblings:
@@ -361,14 +360,24 @@ class NetconfCalculator(BaseCalculator):
                 node_self.append(child_self)
             s_node = self.device.get_schema_node(child_other)
             if s_node.get('type') == 'leaf-list':
+                child_self.set(operation_tag, self.preferred_delete)
                 self._merge_text(child_other, child_self)
             elif s_node.get('type') == 'list':
+                child_self.set(operation_tag, self.preferred_delete)
                 keys = self._get_list_keys(s_node)
                 for key in keys:
                     key_node = child_other.find(key)
                     e = etree.SubElement(
                         child_self, key, nsmap=key_node.nsmap)
                     e.text = key_node.text
+            elif (
+                s_node.get('type') == 'container' and
+                s_node.get('presence') != 'true' and
+                self.preferred_delete == 'delete'
+            ):
+                self.set_delete_operation(child_self, child_other)
+            else:
+                child_self.set(operation_tag, self.preferred_delete)
 
         for child_self, child_other in in_s_and_in_o:
             child_self.set(operation_tag, 'replace')
@@ -1066,7 +1075,6 @@ class NetconfCalculator(BaseCalculator):
         choice_nodes = {}
         for child_self in in_s_not_in_o:
             child_other = etree.Element(child_self.tag,
-                                        {operation_tag: self.preferred_delete},
                                         nsmap=child_self.nsmap)
             if self.diff_type == 'replace':
                 child_self.set(operation_tag, 'replace')
@@ -1084,8 +1092,10 @@ class NetconfCalculator(BaseCalculator):
                 if s_node.get('ordered-by') == 'user' and \
                    s_node.tag not in ordered_by_user:
                     ordered_by_user[s_node.tag] = 'leaf-list'
+                child_other.set(operation_tag, self.preferred_delete)
                 self._merge_text(child_self, child_other)
             elif s_node.get('type') == 'list':
+                child_other.set(operation_tag, self.preferred_delete)
                 keys = self._get_list_keys(s_node)
                 if s_node.get('ordered-by') == 'user' and \
                    s_node.tag not in ordered_by_user:
@@ -1095,12 +1105,19 @@ class NetconfCalculator(BaseCalculator):
                     e = etree.SubElement(
                         child_other, key, nsmap=key_node.nsmap)
                     e.text = key_node.text
+            elif (
+                s_node.get('type') == 'container' and
+                s_node.get('presence') != 'true' and
+                self.preferred_delete == 'delete'
+            ):
+                self.set_delete_operation(child_other, child_self)
+            else:
+                child_other.set(operation_tag, self.preferred_delete)
             if s_node.getparent().get('type') == 'case':
                 # key: choice node, value: case node
                 choice_nodes[s_node.getparent().getparent()] = s_node.getparent()
         for child_other in in_o_not_in_s:
             child_self = etree.Element(child_other.tag,
-                                       {operation_tag: self.preferred_delete},
                                        nsmap=child_other.nsmap)
             if self.preferred_create == 'replace':
                 child_other.set(operation_tag, self.preferred_create)
@@ -1126,8 +1143,10 @@ class NetconfCalculator(BaseCalculator):
                 if s_node.get('ordered-by') == 'user' and \
                    s_node.tag not in ordered_by_user:
                     ordered_by_user[s_node.tag] = 'leaf-list'
+                child_self.set(operation_tag, self.preferred_delete)
                 self._merge_text(child_other, child_self)
             elif s_node.get('type') == 'list':
+                child_self.set(operation_tag, self.preferred_delete)
                 keys = self._get_list_keys(s_node)
                 if s_node.get('ordered-by') == 'user' and \
                    s_node.tag not in ordered_by_user:
@@ -1136,6 +1155,14 @@ class NetconfCalculator(BaseCalculator):
                     key_node = child_other.find(key)
                     e = etree.SubElement(child_self, key, nsmap=key_node.nsmap)
                     e.text = key_node.text
+            elif (
+                s_node.get('type') == 'container' and
+                s_node.get('presence') != 'true' and
+                self.preferred_delete == 'delete'
+            ):
+                self.set_delete_operation(child_self, child_other)
+            else:
+                child_self.set(operation_tag, self.preferred_delete)
         for child_self, child_other in in_s_and_in_o:
             s_node = self.device.get_schema_node(child_self)
             if s_node.get('type') == 'leaf':
@@ -1263,6 +1290,56 @@ class NetconfCalculator(BaseCalculator):
                     self.set_create_operation(child)
         else:
             node.set(operation_tag, 'create')
+
+    def set_delete_operation(self, node, reference_node):
+        '''set_delete_operation
+        Low-level api: Set the `operation` attribute of a node to `delete` when
+        it is not already set. This method is used when the preferred_delete is
+        `delete`.
+        Parameters
+        ----------
+        node : `Element`
+            A config node in a config tree. `delete` operation will be set on
+            descendants of this node.
+        reference_node : `Element`
+            A config node in a config tree as a reference when building the
+            input parameter `node`. This node has descendants that `node` does
+            not have.
+        Returns
+        -------
+        None
+            There is no return of this method.
+        '''
+
+        # Delete operation on non-presence containers is allowed even there is
+        # nothing inside the non-presence container as per ConfD implementation
+        # although the expected behavior is ambiguous in RFC7950. More
+        # discussion can be found in the Tail-F ticket PS-47089. In negative
+        # testing case, if we want the delete operation to be rejected when
+        # there is nothing inside the non-presence container, we have to put
+        # delete operations on the descendants of the non-presence container,
+        # which are not non-presence containers.
+        for reference_child in reference_node:
+            child = etree.SubElement(node, reference_child.tag,
+                                     nsmap=reference_child.nsmap)
+            schema_node = self.device.get_schema_node(reference_child)
+            if schema_node.get('type') == 'leaf-list':
+                child.set(operation_tag, 'delete')
+                self._merge_text(reference_child, child)
+            elif schema_node.get('type') == 'list':
+                child.set(operation_tag, 'delete')
+                keys = self._get_list_keys(schema_node)
+                for key in keys:
+                    key_node = reference_child.find(key)
+                    e = etree.SubElement(child, key, nsmap=key_node.nsmap)
+                    e.text = key_node.text
+            elif (
+                schema_node.get('type') == 'container' and
+                schema_node.get('presence') != 'true'
+            ):
+                self.set_delete_operation(child, reference_child)
+            else:
+                child.set(operation_tag, 'delete')
 
     @staticmethod
     def _url_to_prefix(node, id):

--- a/ncdiff/src/yang/ncdiff/netconf.py
+++ b/ncdiff/src/yang/ncdiff/netconf.py
@@ -1246,10 +1246,13 @@ class NetconfCalculator(BaseCalculator):
         '''
 
         schema_node = self.device.get_schema_node(node)
+
+        # Create operation on non-presence containers is not allowed as per
+        # ConfD implementation although the expected behavior is ambiguous in
+        # RFC7950. More discussion can be found in the Tail-F ticket PS-47089.
         if (
             schema_node.get('type') == 'container' and
-            schema_node.get('presence') != 'true' and
-            len(self.device.default_in_use(schema_node)) > 0
+            schema_node.get('presence') != 'true'
         ):
             for child in node:
                 self.set_create_operation(child)

--- a/ncdiff/src/yang/ncdiff/netconf.py
+++ b/ncdiff/src/yang/ncdiff/netconf.py
@@ -1254,8 +1254,13 @@ class NetconfCalculator(BaseCalculator):
             schema_node.get('type') == 'container' and
             schema_node.get('presence') != 'true'
         ):
+            default_xpaths = [self.device.get_xpath(n)
+                              for n in self.device.default_in_use(schema_node)]
             for child in node:
-                self.set_create_operation(child)
+                child_xpath = self.device.get_xpath(
+                    self.device.get_schema_node(child))
+                if child_xpath not in default_xpaths:
+                    self.set_create_operation(child)
         else:
             node.set(operation_tag, 'create')
 

--- a/ncdiff/src/yang/ncdiff/runningconfig.py
+++ b/ncdiff/src/yang/ncdiff/runningconfig.py
@@ -105,6 +105,7 @@ ORDERLESS_COMMANDS = [
     (re.compile(r'^ *ospfv3 neighbor '), 1),
     (re.compile(r'^ *ospfv3 \d+ ipv(\d) neighbor'), 1),
     (re.compile(r'^ *ospfv3 \d+ neighbor '), 1),
+    (re.compile(r'^ *member vni '), 1),
 ]
 
 # Some commands can be overwritten without a no command. For example, changing
@@ -178,6 +179,7 @@ REPLACING_COMMANDS = [
     ('exit-router-lisp', 'exit'),
     ('exit-address-family', ' exit-address-family'),
 ]
+
 
 class ListDiff(object):
     '''ListDiff

--- a/ncdiff/src/yang/ncdiff/tests/test_ncdiff.py
+++ b/ncdiff/src/yang/ncdiff/tests/test_ncdiff.py
@@ -1544,6 +1544,68 @@ class TestNcDiff(unittest.TestCase):
                     f"but got the delta {delta.nc} instead.",
                 )
 
+    def test_delta_14(self):
+        xml1 = """
+            <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+              <data>
+                <location xmlns="urn:jon">
+                  <alberta>
+                    <name>Calgary</name>
+                  </alberta>
+                </location>
+              </data>
+            </rpc-reply>
+            """
+        xml2 = """
+            <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+              <data>
+                <location xmlns="urn:jon">
+                  <alberta>
+                    <name>Calgary</name>
+                  </alberta>
+                  <other-info>
+                    <geo-facts>
+                      <code>ON</code>
+                    </geo-facts>
+                  </other-info>
+                </location>
+              </data>
+            </rpc-reply>
+            """
+        config1 = Config(self.d, xml1)
+        config2 = Config(self.d, xml2)
+        delta = config2 - config1
+        delta.preferred_create = "create"
+        verification = [
+            # Create operation at "other-info" is not allowed as it is a NP
+            # container.
+            "/nc:config/jon:location/jon:other-info",
+
+            # Create operation at "geo-facts" is not allowed as it is a NP
+            # container.
+            "/nc:config/jon:location/jon:other-info/jon:geo-facts",
+
+            # Create operation at "code" is not allowed as it has default in
+            # use.
+            "/nc:config/jon:location/jon:other-info/jon:geo-facts/jon:code",
+        ]
+        for xpath in verification:
+            nodes = delta.nc.xpath(
+                xpath,
+                namespaces=delta.ns)
+            self.assertEqual(
+                len(nodes),
+                1,
+                f"Expected to find xpath '{xpath}' in delta "
+                f"but the delta is {delta}",
+            )
+            for node in nodes:
+                self.assertIsNone(
+                    node.get(operation_tag),
+                    f"Expected there is no 'create' operation at {xpath} "
+                    f"but got the delta {delta} instead.",
+                )
+
     def test_delta_replace_1(self):
         config_xml1 = """
             <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">

--- a/ncdiff/src/yang/ncdiff/tests/test_ncdiff.py
+++ b/ncdiff/src/yang/ncdiff/tests/test_ncdiff.py
@@ -1709,6 +1709,8 @@ class TestNcDiff(unittest.TestCase):
                 )
 
     def test_delta_replace_1(self):
+        """Test the delta when the diff type is 'replace'.
+        """
         config_xml1 = """
             <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
               <data>

--- a/ncdiff/src/yang/ncdiff/tests/test_ncdiff.py
+++ b/ncdiff/src/yang/ncdiff/tests/test_ncdiff.py
@@ -1497,6 +1497,53 @@ class TestNcDiff(unittest.TestCase):
                     f"but got the delta {delta.nc} instead.",
                 )
 
+    def test_delta_13(self):
+        xml1 = """
+            <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+              <data>
+              </data>
+            </rpc-reply>
+            """
+        xml2 = """
+            <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+              <data>
+                <tracking xmlns="urn:jon">
+                  <logging>
+                    <local>true</local>
+                  </logging>
+                </tracking>
+              </data>
+            </rpc-reply>
+            """
+        config1 = Config(self.d, xml1)
+        config2 = Config(self.d, xml2)
+        delta1 = config2 - config1
+        delta1.preferred_create = "create"
+        verification = [
+            # Create operation at tracking or logging, which are non-presence
+            # containers, is not allowed as per confd implementation although
+            # the expected behavior is ambiguous in RFC7950. More discussion
+            # can be found in the Tail-F ticket PS-47089.
+            (delta1, "/nc:config/jon:tracking/jon:logging/jon:local"),
+        ]
+        for delta, xpath in verification:
+            nodes = delta.nc.xpath(
+                xpath,
+                namespaces=delta.ns)
+            self.assertEqual(
+                len(nodes),
+                1,
+                f"Expected to find xpath '{xpath}' in delta "
+                f"but the delta is {delta.nc}",
+            )
+            for node in nodes:
+                self.assertEqual(
+                    node.get(operation_tag),
+                    "create",
+                    f"Expected 'create' operation at {xpath} "
+                    f"but got the delta {delta.nc} instead.",
+                )
+
     def test_delta_replace_1(self):
         config_xml1 = """
             <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">

--- a/ncdiff/src/yang/ncdiff/tests/test_ncdiff.py
+++ b/ncdiff/src/yang/ncdiff/tests/test_ncdiff.py
@@ -382,6 +382,8 @@ class TestNcDiff(unittest.TestCase):
         self.parser = etree.XMLParser(remove_blank_text=True)
 
     def test_delta_1(self):
+        """Test the delta when preferred_delete is set to remove.
+        """
         xml1 = """
             <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"
                        message-id="101">
@@ -498,6 +500,8 @@ class TestNcDiff(unittest.TestCase):
         self.assertEqual(str(delta2).strip(), expected_delta2.strip())
 
     def test_delta_2(self):
+        """Test the delta when config in a list instance is changed.
+        """
         xml1 = """
             <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"
                        message-id="101">
@@ -598,6 +602,8 @@ class TestNcDiff(unittest.TestCase):
         self.assertEqual(str(delta2).strip(), expected_delta2.strip())
 
     def test_delta_3(self):
+        """Test the delta when a leaf-list has ordered-by set to user.
+        """
         config_xml1 = """
             <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
               <data>
@@ -682,6 +688,8 @@ class TestNcDiff(unittest.TestCase):
         self.assertEqual(config1, config4)
 
     def test_delta_4(self):
+        """Test the delta when a list has ordered-by set to user.
+        """
         config_xml1 = """
             <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
               <data>
@@ -808,6 +816,9 @@ class TestNcDiff(unittest.TestCase):
         self.assertEqual(config1, config4)
 
     def test_delta_5(self):
+        """Test the delta when a list has ordered-by set to user. Note that
+        preferred_create, preferred_replace and preferred_delete are set.
+        """
         config_xml1 = """
             <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
               <data>
@@ -929,6 +940,9 @@ class TestNcDiff(unittest.TestCase):
         self.assertEqual(config1, config4)
 
     def test_delta_6(self):
+        """Test the delta when a leaf-list has ordered-by set to user. Note
+        that preferred_create, preferred_replace and preferred_delete are set.
+        """
         config_xml1 = """
             <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
               <data>
@@ -1018,6 +1032,8 @@ class TestNcDiff(unittest.TestCase):
         self.assertEqual(config1, config4)
 
     def test_delta_7(self):
+        """Test the delta when choices are involved.
+        """
         # choice
         no_choice_xml = """
             <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"
@@ -1168,6 +1184,8 @@ class TestNcDiff(unittest.TestCase):
         self.assertEqual(str(delta6).strip(), expected_delta1.strip())
 
     def test_delta_8(self):
+        """Test the delta when multiple choices are involved.
+        """
         # multiple choices
         xml1 = """
             <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"
@@ -1277,6 +1295,8 @@ class TestNcDiff(unittest.TestCase):
         self.assertEqual(str(delta2).strip(), expected_delta2.strip())
 
     def test_delta_9(self):
+        """Test the delta when a list is under a choice.
+        """
         # choice with list
         xml1 = """
             <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
@@ -1326,6 +1346,8 @@ class TestNcDiff(unittest.TestCase):
         self.assertEqual(str(delta2).strip(), expected_delta2.strip())
 
     def test_delta_10(self):
+        """Test the delta when multiple nodes are under a case.
+        """
         # choice multiple nodes in one case
         xml1 = """
             <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
@@ -1369,6 +1391,10 @@ class TestNcDiff(unittest.TestCase):
         self.assertEqual(str(delta2).strip(), expected_delta2.strip())
 
     def test_delta_11(self):
+        """Test the behavior of preferred_create="create" when creating
+        something in a container. The expected behavior involves whether there
+        is a default statement.
+        """
         xml1 = """
             <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
               <data>
@@ -1438,6 +1464,10 @@ class TestNcDiff(unittest.TestCase):
                 )
 
     def test_delta_12(self):
+        """Test the behavior of preferred_create="create" when creating
+        something in a choice. The expected behavior involves whether there
+        is a default statement.
+        """
         xml1 = """
             <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
               <data>
@@ -1499,6 +1529,11 @@ class TestNcDiff(unittest.TestCase):
                 )
 
     def test_delta_13(self):
+        """Test the behavior of preferred_create="create" when creating
+        something in a non-presence container. The expected behavior is to
+        create individual leaves within the container instead of the
+        non-presence container.
+        """
         xml1 = """
             <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
               <data>
@@ -1546,6 +1581,10 @@ class TestNcDiff(unittest.TestCase):
                 )
 
     def test_delta_14(self):
+        """Test the behavior of preferred_create="create" when creating
+        something in a non-presence container. The expected behavior involves
+        whether there is default in use.
+        """
         xml1 = """
             <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
               <data>
@@ -1608,6 +1647,11 @@ class TestNcDiff(unittest.TestCase):
                 )
 
     def test_delta_15(self):
+        """Test the behavior of preferred_delete="delete" when deleting
+        something in a non-presence container. The expected behavior is to
+        delete individual leaves within the container instead of the
+        non-presence container.
+        """
         xml1 = """
             <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
               <data>

--- a/ncdiff/src/yang/ncdiff/tests/yang/jon.yang
+++ b/ncdiff/src/yang/ncdiff/tests/yang/jon.yang
@@ -69,7 +69,7 @@ module jon {
 
   leaf-list store {
     ordered-by user;
-    default "Target";
+    type string;
   }
 
   container location {


### PR DESCRIPTION
In the light of current ConfD behavior, it is better to avoid 'create' operation on non-presence containers. More details can be found in the Tail-F ticket PS-47089.

The ticket mentions that the expected behavior of 'delete' operation on non-presence containers is ambiguous. This update avoids 'delete' operation on non-presence containers, too.

Unit test is added.

```
(pyats-dev) [yuekyang@yangtest-lnx tests]$ python -m unittest test_ncdiff
/auto/ottawa-xe-mpls/users/yuekyang/pyats-dev/github/genielibs/pkgs/conf-pkg/src/genie/libs/conf/device/__init__.py:46: UnsupportedDeviceOsWarning: Device dummy OS is unknown; Extended Device functionality will not be available: mandatory field 'os' was not given in the yaml file
  warnings.warn(
2025-05-02T11:35:07: %NETCONF-INFO: NETCONF CONNECTED
Error in Netconf reply when getting /netconf-state/schemas from YANG module 'ietf-netconf-monitoring':
<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
  <rpc-error>
    <error-type>rpc</error-type>
    <error-tag>missing-attribute</error-tag>
    <error-severity>error</error-severity>
    <error-info>
      <bad-attribute>message-id</bad-attribute>
      <bad-element>rpc</bad-element>
    </error-info>
  </rpc-error>
</rpc-reply>

Error in Netconf reply when getting /modules-state/module from YANG module 'ietf-yang-library':
<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
  <rpc-error>
    <error-type>rpc</error-type>
    <error-tag>missing-attribute</error-tag>
    <error-severity>error</error-severity>
    <error-info>
      <bad-attribute>message-id</bad-attribute>
      <bad-element>rpc</bad-element>
    </error-info>
  </rpc-error>
</rpc-reply>

.......................................
----------------------------------------------------------------------
Ran 39 tests in 0.412s

OK
(pyats-dev) [yuekyang@yangtest-lnx tests]$
```