### PR TITLE
Added orderless config

### DIFF
--- a/ncdiff/src/yang/ncdiff/runningconfig.py
+++ b/ncdiff/src/yang/ncdiff/runningconfig.py
@@ -107,6 +107,7 @@ ORDERLESS_COMMANDS = [
     (re.compile(r'^ *ospfv3 \d+ neighbor '), 1),
     (re.compile(r'^ *ipv6 route '), 0),
     (re.compile(r'^ *ip route '), 0),
+    (re.compile(r'^ *description '), 1),
 ]
 
 # Some commands can be overwritten without a no command. For example, changing


### PR DESCRIPTION
```
20348:  Diff result:   class-map match-any system-cpp-police-ewlc-control
20349:  -   description EWLC Control
20350:  +   description EWLC Control
20351:    class-map match-any system-cpp-default
20352:  -   description EWLC Data, Inter FED Traffic
20353:  +   description EWLC Data, Inter FED Traffic
20354:    class-map match-any system-cpp-police-high-rate-app
20355:  -   description High Rate Applications
20356:  +   description High Rate Applications
20357:    line vty 0 4
20358:  -   privilege level 15
20359: 
20360:  Failed reason: Device running configuration is not same as Day 1
```