### PR TITLE
Fix: Running config order for aaa parameters

### DIFF
--- a/ncdiff/docs/changelog/undistributed/changelog_fix_running_config_diff_202509112017.rst
+++ b/ncdiff/docs/changelog/undistributed/changelog_fix_running_config_diff_202509112017.rst
@@ -4,3 +4,5 @@
 * yang.ncdiff
     * updated orderless config for aaa attribute list at depth 0.
     * updated orderless config for attribute type at depth 1.
+    * updated orderless config for access-session attributes filter-list list at dept 0
+    * updated orderless config for vlan-id,cdp,lldp,dhcpv6,http at depth 1.

--- a/ncdiff/docs/changelog/undistributed/changelog_fix_running_config_diff_202509112017.rst
+++ b/ncdiff/docs/changelog/undistributed/changelog_fix_running_config_diff_202509112017.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                                Fix
+--------------------------------------------------------------------------------
+* yang.ncdiff
+    * updated orderless config for aaa attribute list at depth 0.
+    * updated orderless config for attribute type at depth 1.

--- a/ncdiff/src/yang/ncdiff/runningconfig.py
+++ b/ncdiff/src/yang/ncdiff/runningconfig.py
@@ -108,6 +108,8 @@ ORDERLESS_COMMANDS = [
     (re.compile(r'^ *member vni '), 1),
     (re.compile(r'^ *ipv6 route '), 0),
     (re.compile(r'^ *ip route '), 0),
+    (re.compile(r'^ *aaa attribute list '), 0),
+    (re.compile(r'^ *attribute type '), 1),
 ]
 
 # Some commands can be overwritten without a no command. For example, changing

--- a/ncdiff/src/yang/ncdiff/runningconfig.py
+++ b/ncdiff/src/yang/ncdiff/runningconfig.py
@@ -110,6 +110,8 @@ ORDERLESS_COMMANDS = [
     (re.compile(r'^ *ip route '), 0),
     (re.compile(r'^ *aaa attribute list '), 0),
     (re.compile(r'^ *attribute type '), 1),
+    (re.compile(r'^ *access-session attributes filter-list list '), 0),
+    (re.compile(r'^ *(vlan-id|cdp|lldp|dhcpv6?|http)$'), 1),
 ]
 
 # Some commands can be overwritten without a no command. For example, changing

--- a/ncdiff/src/yang/ncdiff/runningconfig.py
+++ b/ncdiff/src/yang/ncdiff/runningconfig.py
@@ -108,16 +108,13 @@ ORDERLESS_COMMANDS = [
     (re.compile(r'^ *member vni '), 1),
     (re.compile(r'^ *ipv6 route '), 0),
     (re.compile(r'^ *ip route '), 0),
-<<<<<<< HEAD
+    (re.compile(r'^ *ip wccp '), 1),
+    (re.compile(r'^ *match identity remote '), 1),
+    (re.compile(r'^ *event manager environment '), 0),
     (re.compile(r'^ *aaa attribute list '), 0),
     (re.compile(r'^ *attribute type '), 1),
     (re.compile(r'^ *access-session attributes filter-list list '), 0),
     (re.compile(r'^ *(vlan-id|cdp|lldp|dhcpv6?|http)$'), 1),
-=======
-    (re.compile(r'^ *ip wccp '), 1),
-    (re.compile(r'^ *match identity remote '), 1),
-    (re.compile(r'^ *event manager environment '), 0),
->>>>>>> main
 ]
 
 # Some commands can be overwritten without a no command. For example, changing


### PR DESCRIPTION
 updated orderless config for: 
 aaa attribute list at depth 0.
 attribute type at depth 1.
 access-session attributes filter-list list at dept 0
 config for vlan-id,cdp,lldp,dhcpv6,http at depth 1.