### PR TITLE
Fixes to netconf on SSH tunnels

### DIFF
--- a/connector/docs/changelog/undistributed/netconf_sshtunnel_logging.rst
+++ b/connector/docs/changelog/undistributed/netconf_sshtunnel_logging.rst
@@ -3,4 +3,5 @@ Fix
 --------------------------------------------------------------------------------
 * yang.connector
     * Modified Netconf:
-        * Capture SSH tunnel setup and ncclient session logs in the NETCONF per-connection log file.
+        * Captured SSH tunnel setup and ncclient session logs in the per-connection NETCONF log file.
+        * Avoided attaching the pyATS tasklog handler when its stream is unavailable.

--- a/connector/docs/changelog/undistributed/netconf_sshtunnel_logging.rst
+++ b/connector/docs/changelog/undistributed/netconf_sshtunnel_logging.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+Fix
+--------------------------------------------------------------------------------
+* yang.connector
+    * Modified Netconf:
+        * Capture SSH tunnel setup and ncclient session logs in the NETCONF per-connection log file.

--- a/connector/src/yang/connector/netconf.py
+++ b/connector/src/yang/connector/netconf.py
@@ -127,6 +127,26 @@ class pyATS_TaskLog_Adapter(logging.StreamHandler):
         return self._pyats_handlers.tasklog.stream
 
 
+class NetconfLogForwardingHandler(logging.Handler):
+    """Forward log records from helper loggers to the connection logger."""
+
+    def __init__(self, log):
+        super().__init__()
+        self.log = log
+
+    def emit(self, record):
+        if getattr(record, '_yang_connector_forwarded', False):
+            return
+        if not self.log.isEnabledFor(record.levelno):
+            return
+
+        record._yang_connector_forwarded = True
+        try:
+            self.log.handle(record)
+        finally:
+            del record._yang_connector_forwarded
+
+
 class NetconfSessionLogHandler(logging.Handler):
     """Logging handler that pretty prints ncclient XML."""
 
@@ -152,6 +172,11 @@ class NetconfSessionLogHandler(logging.Handler):
             except Exception:
                 # Unable to handle record so leave it unchanged
                 pass
+
+        session = getattr(record, 'session', None)
+        log = getattr(session, '_yang_connector_log', None)
+        if log:
+            NetconfLogForwardingHandler(log).emit(record)
 
 
 nccl.addHandler(NetconfSessionLogHandler())
@@ -317,7 +342,9 @@ class Netconf(manager.Manager, BaseConnection):
         self.log = logging.getLogger('netconf.%s' % logger_name)
 
         # workaround for double invocation that somehow happens in robot
-        self.log.handlers.clear()
+        for handler in self.log.handlers[:]:
+            self.log.removeHandler(handler)
+            handler.close()
         self.log.filters.clear()
 
         # default log level
@@ -378,6 +405,12 @@ class Netconf(manager.Manager, BaseConnection):
         # if debug_mode is True, enable debug mode
         if self.debug:
             self.log.setLevel(logging.DEBUG)
+            nccl.setLevel(logging.DEBUG)
+        else:
+            nccl.setLevel(logging.INFO)
+
+    def configure_session_logging(self):
+        self.session._yang_connector_log = self.log
 
     def connect(self):
         '''connect
@@ -489,6 +522,7 @@ class Netconf(manager.Manager, BaseConnection):
 
         if not self.session.is_alive():
             self._session = transport.SSHSession(self._device_handler)
+        self.configure_session_logging()
 
         # default values
         defaults = {
@@ -533,6 +567,9 @@ class Netconf(manager.Manager, BaseConnection):
         # support sshtunnel
         if 'sshtunnel' in defaults:
             from unicon.sshutils import sshtunnel
+            tunnel_logger = logging.getLogger('unicon.sshutils')
+            tunnel_log_handler = NetconfLogForwardingHandler(self.log)
+            tunnel_logger.addHandler(tunnel_log_handler)
             try:
                 tunnel_port = sshtunnel.auto_tunnel_add(self.device, self.via)
                 if tunnel_port:
@@ -543,6 +580,8 @@ class Netconf(manager.Manager, BaseConnection):
                 raise AttributeError("Cannot add ssh tunnel. \
                 Connection %s may not have ip/host or port.\n%s"
                                      % (self.via, err))
+            finally:
+                tunnel_logger.removeHandler(tunnel_log_handler)
             del defaults['sshtunnel']
 
         defaults = {k: getattr(self, k, v) for k, v in defaults.items()}

--- a/connector/src/yang/connector/netconf.py
+++ b/connector/src/yang/connector/netconf.py
@@ -3,6 +3,7 @@
 import re
 import time
 import atexit
+import copy
 import logging
 import subprocess
 import datetime
@@ -128,7 +129,7 @@ class pyATS_TaskLog_Adapter(logging.StreamHandler):
 
 
 class NetconfLogForwardingHandler(logging.Handler):
-    """Forward log records from helper loggers to the connection logger."""
+    """Forward helper log records to the connection log file."""
 
     def __init__(self, log):
         super().__init__()
@@ -140,11 +141,14 @@ class NetconfLogForwardingHandler(logging.Handler):
         if not self.log.isEnabledFor(record.levelno):
             return
 
-        record._yang_connector_forwarded = True
-        try:
-            self.log.handle(record)
-        finally:
-            del record._yang_connector_forwarded
+        forwarded_record = copy.copy(record)
+        forwarded_record._yang_connector_forwarded = True
+        for handler in self.log.handlers:
+            if not isinstance(handler, logging.FileHandler):
+                continue
+            if record.levelno < handler.level:
+                continue
+            handler.handle(forwarded_record)
 
 
 class NetconfSessionLogHandler(logging.Handler):
@@ -394,7 +398,9 @@ class Netconf(manager.Manager, BaseConnection):
             pass
         else:
             # we're in pyATS, use pyATS loggers
-            if not self.no_pyats_tasklog:
+            tasklog = getattr(managed_handlers, 'tasklog', None)
+            tasklog_stream = getattr(tasklog, 'stream', None)
+            if not self.no_pyats_tasklog and tasklog_stream is not None:
                 pta = pyATS_TaskLog_Adapter()
                 nsf = NetconfScreenFormatter(fmt=TaskLogFormatter.MESSAGE_FORMAT)
                 nsf.MAX_LINES = self.settings.get('NETCONF_SCREEN_LOGGING_MAX_LINES', 40)

--- a/connector/src/yang/connector/netconf.py
+++ b/connector/src/yang/connector/netconf.py
@@ -13,6 +13,7 @@ from threading import Thread, Event
 from ncclient import manager
 from ncclient import operations
 from ncclient import transport
+from ncclient.logging_ import SessionLoggerAdapter
 from ncclient.operations.retrieve import GetReply
 from ncclient.devices.default import DefaultDeviceHandler
 from ncclient.operations.errors import TimeoutExpiredError
@@ -183,7 +184,40 @@ class NetconfSessionLogHandler(logging.Handler):
             NetconfLogForwardingHandler(log).emit(record)
 
 
-nccl.addHandler(NetconfSessionLogHandler())
+class NetconfSessionLoggerAdapter(SessionLoggerAdapter):
+    """Session logger adapter that forwards records to the connection log."""
+
+    def __init__(self, logger, extra, log):
+        super().__init__(logger, extra)
+        self.netconf_log = log
+
+    def log(self, level, msg, *args, **kwargs):
+        if not self.logger.isEnabledFor(level):
+            self.forward(level, msg, args, kwargs)
+        return super().log(level, msg, *args, **kwargs)
+
+    def forward(self, level, msg, args, kwargs):
+        if not self.netconf_log.isEnabledFor(level):
+            return
+
+        kwargs = kwargs.copy()
+        if 'extra' in kwargs:
+            kwargs['extra'] = kwargs['extra'].copy()
+        msg, kwargs = self.process(msg, kwargs)
+
+        extra = kwargs.pop('extra', None)
+        exc_info = kwargs.pop('exc_info', None)
+        stack_info = kwargs.pop('stack_info', None)
+        kwargs.pop('stacklevel', None)
+
+        record = self.logger.makeRecord(
+            self.logger.name, level, __file__, 0, msg, args, exc_info,
+            extra=extra, sinfo=stack_info)
+        ncclient_session_log_handler.emit(record)
+
+
+ncclient_session_log_handler = NetconfSessionLogHandler()
+nccl.addHandler(ncclient_session_log_handler)
 
 
 class Netconf(manager.Manager, BaseConnection):
@@ -411,12 +445,21 @@ class Netconf(manager.Manager, BaseConnection):
         # if debug_mode is True, enable debug mode
         if self.debug:
             self.log.setLevel(logging.DEBUG)
-            nccl.setLevel(logging.DEBUG)
-        else:
-            nccl.setLevel(logging.INFO)
 
     def configure_session_logging(self):
         self.session._yang_connector_log = self.log
+        session_logger = getattr(self.session, 'logger', None)
+        if isinstance(session_logger, NetconfSessionLoggerAdapter):
+            session_logger.netconf_log = self.log
+            return
+
+        logger = getattr(session_logger, 'logger',
+                         logging.getLogger('ncclient.transport.ssh'))
+        extra = getattr(session_logger, 'extra', {})
+        extra = extra.copy()
+        extra['session'] = self.session
+        self.session.logger = NetconfSessionLoggerAdapter(
+            logger, extra, self.log)
 
     def connect(self):
         '''connect
@@ -575,7 +618,10 @@ class Netconf(manager.Manager, BaseConnection):
             from unicon.sshutils import sshtunnel
             tunnel_logger = logging.getLogger('unicon.sshutils')
             tunnel_log_handler = NetconfLogForwardingHandler(self.log)
+            tunnel_logger_level = tunnel_logger.level
             tunnel_logger.addHandler(tunnel_log_handler)
+            if tunnel_logger.getEffectiveLevel() > logging.INFO:
+                tunnel_logger.setLevel(logging.INFO)
             try:
                 tunnel_port = sshtunnel.auto_tunnel_add(self.device, self.via)
                 if tunnel_port:
@@ -588,6 +634,7 @@ class Netconf(manager.Manager, BaseConnection):
                                      % (self.via, err))
             finally:
                 tunnel_logger.removeHandler(tunnel_log_handler)
+                tunnel_logger.setLevel(tunnel_logger_level)
             del defaults['sshtunnel']
 
         defaults = {k: getattr(self, k, v) for k, v in defaults.items()}

--- a/connector/src/yang/connector/tests/test_yang.py
+++ b/connector/src/yang/connector/tests/test_yang.py
@@ -283,6 +283,72 @@ class TestYang(unittest.TestCase):
             if os.path.exists(logfile):
                 os.remove(logfile)
 
+    def test_log_forwarding_only_writes_file_handlers(self):
+        class FailingHandler(logging.Handler):
+            def emit(self, record):
+                raise AssertionError('non-file handler should not be used')
+
+        logfile = tempfile.mktemp(suffix='.log')
+        log = logging.getLogger('test.netconf.forwarding')
+        log.handlers.clear()
+        log.setLevel(logging.INFO)
+        log.propagate = False
+
+        file_handler = logging.FileHandler(logfile)
+        file_handler.setFormatter(yang.connector.netconf.NetconfFormatter())
+        log.addHandler(FailingHandler())
+        log.addHandler(file_handler)
+
+        try:
+            record = logging.LogRecord(
+                'unicon.sshutils', logging.INFO, __file__, 0,
+                'Adding local tunnel %s', ('127.0.0.1:123',), None)
+            handler = yang.connector.netconf.NetconfLogForwardingHandler(log)
+            handler.emit(record)
+
+            with open(logfile) as log_file:
+                log_content = log_file.read()
+
+            self.assertIn('Adding local tunnel 127.0.0.1:123', log_content)
+        finally:
+            for handler in log.handlers[:]:
+                log.removeHandler(handler)
+                handler.close()
+            if os.path.exists(logfile):
+                os.remove(logfile)
+
+    def test_configure_logging_skips_unavailable_tasklog(self):
+        from pyats.log import managed_handlers
+
+        logfile = tempfile.mktemp(suffix='.log')
+        nc_device = yang.connector.Netconf(device=self.device,
+                                           alias='nc',
+                                           via='netconf',
+                                           logfile=logfile,
+                                           log_stdout=False)
+        original_stream = managed_handlers.tasklog.stream
+
+        try:
+            managed_handlers.tasklog.stream = None
+            nc_device.configure_logging()
+
+            tasklog_handlers = [
+                handler for handler in nc_device.log.handlers
+                if isinstance(
+                    handler,
+                    yang.connector.netconf.pyATS_TaskLog_Adapter)
+            ]
+            self.assertEqual(tasklog_handlers, [])
+
+            nc_device.log.info('tasklog stream unavailable')
+        finally:
+            managed_handlers.tasklog.stream = original_stream
+            for handler in nc_device.log.handlers[:]:
+                nc_device.log.removeHandler(handler)
+                handler.close()
+            if os.path.exists(logfile):
+                os.remove(logfile)
+
     @patch('yang.connector.netconf.RawRPC', new=MyRawRPC)
     def test_request(self):
         self.nc_device._session = MySSHSession()

--- a/connector/src/yang/connector/tests/test_yang.py
+++ b/connector/src/yang/connector/tests/test_yang.py
@@ -1,12 +1,16 @@
 #!/bin/env python
 """ Unit tests for the yang.connector cisco-shared package. """
 
+import logging
+import os
+import tempfile
 import unittest
 from ncclient import manager
 from ncclient import transport
 from ncclient.devices.default import DefaultDeviceHandler
 from pyats.topology import loader
 from pyats.connections import BaseConnection
+from pyats.datastructures import AttrDict
 from unittest.mock import Mock, patch
 import yang.connector
 
@@ -32,6 +36,7 @@ class MySSHSession():
         return self._connected
 
     def connect(self, **kwargs):
+        self.connect_kwargs = kwargs
         self._connected = True
         self.transport = MyTransportSession()
 
@@ -62,6 +67,7 @@ class MySSHSession2():
         return self._connected
 
     def connect(self, **kwargs):
+        self.connect_kwargs = kwargs
         if kwargs['username'] == 'admin' and kwargs['password'] == 'admin':
             self._connected = True
             self.transport = MyTransportSession()
@@ -196,6 +202,86 @@ class TestYang(unittest.TestCase):
         generated_value = nc_device.connected
         expected_value = False
         self.assertEqual(generated_value, expected_value)
+
+    def test_connect_sshtunnel_logging(self):
+        yaml = \
+            'devices:\n' \
+            '    dummy:\n' \
+            '        os: iosxe\n' \
+            '        type: dummy_device\n' \
+            '        connections:\n' \
+            '            netconf:\n' \
+            '                class: yang.connector.Netconf\n' \
+            '                protocol: netconf\n' \
+            '                ip : "1.2.3.4"\n' \
+            '                port: 830\n' \
+            '                username: admin\n' \
+            '                password: admin\n' \
+            '                sshtunnel:\n' \
+            '                    host: proxy\n'
+
+        testbed = loader.load(yaml)
+        device = testbed.devices['dummy']
+        device.connections.netconf.sshtunnel = AttrDict(
+            device.connections.netconf.sshtunnel)
+        device.connections.netconf.sshtunnel.tunnel_ip = '127.0.0.1'
+        logfile = tempfile.mktemp(suffix='.log')
+
+        nc_device = yang.connector.Netconf(device=device,
+                                           alias='nc',
+                                           via='netconf',
+                                           logfile=logfile,
+                                           log_stdout=False,
+                                           no_pyats_tasklog=True)
+        nc_device._session = MySSHSession()
+
+        def add_tunnel(device, via):
+            logging.getLogger('unicon.sshutils').info(
+                "Device '%s' connection '%s' via new SSH tunnel %s:%s",
+                device.name, via, '127.0.0.1', 123)
+            return 123
+
+        try:
+            with patch('unicon.sshutils.sshtunnel.auto_tunnel_add',
+                       side_effect=add_tunnel):
+                nc_device.connect()
+
+            with open(logfile) as log_file:
+                log_content = log_file.read()
+
+            self.assertIn('via new SSH tunnel', log_content)
+            self.assertIn('NETCONF CONNECTED', log_content)
+            self.assertEqual(nc_device.session.connect_kwargs['host'],
+                             '127.0.0.1')
+            self.assertEqual(nc_device.session.connect_kwargs['port'], 123)
+        finally:
+            if os.path.exists(logfile):
+                os.remove(logfile)
+
+    def test_ncclient_session_logging(self):
+        logfile = tempfile.mktemp(suffix='.log')
+        nc_device = yang.connector.Netconf(device=self.device,
+                                           alias='nc',
+                                           via='netconf',
+                                           logfile=logfile,
+                                           log_stdout=False,
+                                           no_pyats_tasklog=True)
+        nc_device._session = MySSHSession()
+
+        try:
+            nc_device.connect()
+            logging.getLogger('ncclient.transport.ssh').info(
+                'Sending:\n%s', b'<hello/>',
+                extra={'session': nc_device.session})
+
+            with open(logfile) as log_file:
+                log_content = log_file.read()
+
+            self.assertIn('Sending:', log_content)
+            self.assertIn('<hello/>', log_content)
+        finally:
+            if os.path.exists(logfile):
+                os.remove(logfile)
 
     @patch('yang.connector.netconf.RawRPC', new=MyRawRPC)
     def test_request(self):

--- a/connector/src/yang/connector/tests/test_yang.py
+++ b/connector/src/yang/connector/tests/test_yang.py
@@ -35,6 +35,10 @@ class MySSHSession():
     def connected(self):
         return self._connected
 
+    @property
+    def id(self):
+        return None
+
     def connect(self, **kwargs):
         self.connect_kwargs = kwargs
         self._connected = True
@@ -65,6 +69,10 @@ class MySSHSession2():
     @property
     def connected(self):
         return self._connected
+
+    @property
+    def id(self):
+        return None
 
     def connect(self, **kwargs):
         self.connect_kwargs = kwargs
@@ -226,6 +234,8 @@ class TestYang(unittest.TestCase):
             device.connections.netconf.sshtunnel)
         device.connections.netconf.sshtunnel.tunnel_ip = '127.0.0.1'
         logfile = tempfile.mktemp(suffix='.log')
+        tunnel_logger = logging.getLogger('unicon.sshutils')
+        original_tunnel_level = tunnel_logger.level
 
         nc_device = yang.connector.Netconf(device=device,
                                            alias='nc',
@@ -242,6 +252,7 @@ class TestYang(unittest.TestCase):
             return 123
 
         try:
+            tunnel_logger.setLevel(logging.WARNING)
             with patch('unicon.sshutils.sshtunnel.auto_tunnel_add',
                        side_effect=add_tunnel):
                 nc_device.connect()
@@ -254,12 +265,18 @@ class TestYang(unittest.TestCase):
             self.assertEqual(nc_device.session.connect_kwargs['host'],
                              '127.0.0.1')
             self.assertEqual(nc_device.session.connect_kwargs['port'], 123)
+            self.assertEqual(tunnel_logger.level, logging.WARNING)
         finally:
+            tunnel_logger.setLevel(original_tunnel_level)
             if os.path.exists(logfile):
                 os.remove(logfile)
 
     def test_ncclient_session_logging(self):
         logfile = tempfile.mktemp(suffix='.log')
+        ncclient_logger = logging.getLogger('ncclient')
+        ncclient_ssh_logger = logging.getLogger('ncclient.transport.ssh')
+        original_ncclient_level = ncclient_logger.level
+        original_ncclient_ssh_level = ncclient_ssh_logger.level
         nc_device = yang.connector.Netconf(device=self.device,
                                            alias='nc',
                                            via='netconf',
@@ -269,8 +286,10 @@ class TestYang(unittest.TestCase):
         nc_device._session = MySSHSession()
 
         try:
+            ncclient_logger.setLevel(logging.WARNING)
+            ncclient_ssh_logger.setLevel(logging.NOTSET)
             nc_device.connect()
-            logging.getLogger('ncclient.transport.ssh').info(
+            nc_device.session.logger.info(
                 'Sending:\n%s', b'<hello/>',
                 extra={'session': nc_device.session})
 
@@ -279,7 +298,42 @@ class TestYang(unittest.TestCase):
 
             self.assertIn('Sending:', log_content)
             self.assertIn('<hello/>', log_content)
+            self.assertEqual(ncclient_logger.level, logging.WARNING)
+            self.assertEqual(ncclient_ssh_logger.level, logging.NOTSET)
         finally:
+            ncclient_logger.setLevel(original_ncclient_level)
+            ncclient_ssh_logger.setLevel(original_ncclient_ssh_level)
+            if os.path.exists(logfile):
+                os.remove(logfile)
+
+    def test_ncclient_debug_session_logging(self):
+        logfile = tempfile.mktemp(suffix='.log')
+        ncclient_logger = logging.getLogger('ncclient')
+        original_ncclient_level = ncclient_logger.level
+        nc_device = yang.connector.Netconf(device=self.device,
+                                           alias='nc',
+                                           via='netconf',
+                                           logfile=logfile,
+                                           log_stdout=False,
+                                           no_pyats_tasklog=True,
+                                           debug=True)
+        nc_device._session = MySSHSession()
+
+        try:
+            ncclient_logger.setLevel(logging.WARNING)
+            nc_device.connect()
+            nc_device.session.logger.debug(
+                'Received:\n%s', b'<rpc-reply/>',
+                extra={'session': nc_device.session})
+
+            with open(logfile) as log_file:
+                log_content = log_file.read()
+
+            self.assertIn('Received:', log_content)
+            self.assertIn('<rpc-reply/>', log_content)
+            self.assertEqual(ncclient_logger.level, logging.WARNING)
+        finally:
+            ncclient_logger.setLevel(original_ncclient_level)
             if os.path.exists(logfile):
                 os.remove(logfile)
 


### PR DESCRIPTION
## Summary

Fixes NETCONF per-connection logging when the NETCONF connection is established through an SSH tunnel.

Previously, logs emitted during SSH tunnel setup and ncclient session negotiation were not captured in the NETCONF per-connection log file. This change forwards the relevant tunnel and ncclient log records to the NETCONF file handler.

Also fixes a logging error seen when the pyATS tasklog stream is unavailable:

```text
AttributeError: 'NoneType' object has no attribute 'write'
```

The NETCONF logger now skips attaching the pyATS tasklog adapter when the tasklog stream is not available.

## Manual Test

Using a testbed with a NETCONF connection configured with `sshtunnel`, ran:

```python
device.connect(via='netconf')
```

Verified that the generated NETCONF per-connection log file contains SSH tunnel setup logs, ncclient session logs, and the NETCONF connected message.

Example sanitized log content:

```text
%NETCONF-INFO: Connecting proxy host <proxy>
%NETCONF-INFO: Adding local tunnel 127.0.0.1:<local-port> for <device-host>:830
%NETCONF-INFO: Device '<device>' connection 'netconf' via new SSH tunnel 127.0.0.1:<local-port>
%NETCONF-INFO: [host 127.0.0.1 ...] Sending:
%NETCONF-INFO: [host 127.0.0.1 ...] Received message from host
%NETCONF-INFO: [host 127.0.0.1 ...] initialized: session-id=<session-id>
%NETCONF-INFO: NETCONF CONNECTED
```

## Automated Tests

```bash
python -m unittest discover src/yang/connector/tests -v
# Ran 26 tests: OK, skipped=3

python -m unittest discover . -v
# from ncdiff/src/yang/ncdiff/tests
# Ran 78 tests: OK
```

Total:

```text
104 tests passed
3 tests skipped
```