### PR TITLE
Update lxml requirement for Python 3.13 CI

### DIFF
--- a/connector/requirements.txt
+++ b/connector/requirements.txt
@@ -1,3 +1,3 @@
 paramiko >= 1.15.1
-lxml >= 3.3.0, <5.0.0
+lxml >= 6.0.1
 ncclient >= 0.6.6

--- a/connector/setup.py
+++ b/connector/setup.py
@@ -177,7 +177,7 @@ setup(
     # package dependencies
     install_requires =  [
         'paramiko >= 1.15.1',
-        'lxml >= 3.3.0',
+        'lxml >= 6.0.1',
         'ncclient >= 0.6.6',
         'grpcio',
         'protobuf'


### PR DESCRIPTION
## Summary
- require lxml >= 6.0.1 in connector setup metadata
- align connector/requirements.txt with the same minimum

## Rationale
Python 3.13 and 3.14 do not have compatible lxml <5 binary wheels on Linux. The CI workflow was downgrading from the working pyATS-installed lxml 6.x to lxml 4.9.4 from source, which failed without libxml2/libxslt development headers.